### PR TITLE
Subtitle field (iOS only)

### DIFF
--- a/src/main/java/com/kinoroy/expo/push/Message.java
+++ b/src/main/java/com/kinoroy/expo/push/Message.java
@@ -29,6 +29,8 @@ public final class Message {
 
     private String channelId;
 
+    private String subtitle;
+
     private Message() {}
 
     /**
@@ -111,6 +113,13 @@ public final class Message {
     public String getChannelId() {
         return channelId;
     }
+    /**
+     * @return The subtitle to display in the notification below the title.
+     * This currently only affects iOS.
+     */
+    public String getSubtitle() {
+        return subtitle;
+    }
 
     /**
      * A class to help contruct messages
@@ -136,6 +145,8 @@ public final class Message {
         private Integer badge;
 
         private String channelId;
+
+        private String subtitle;
 
         /**
          * @param to A token of the form ExponentPushToken[xxxxxxx]
@@ -228,6 +239,15 @@ public final class Message {
             return this;
         }
 
+        /**
+         * The subtitle to display in the notification below the title.
+         * This currently only affects iOS.
+         */
+        public Builder subtitle(String subtitle) {
+            this.subtitle = subtitle;
+            return this;
+        }
+
         public Message build() {
             Message message = new Message();
 
@@ -250,6 +270,7 @@ public final class Message {
             }
             message.badge = badge;
             message.channelId = channelId;
+            message.subtitle = subtitle;
 
             return message;
         }

--- a/src/test/java/com/kinoroy/expo/push/TestModels.java
+++ b/src/test/java/com/kinoroy/expo/push/TestModels.java
@@ -41,6 +41,7 @@ public class TestModels {
                 .expiration(Instant.ofEpochSecond(1540145105))
                 .ttl(Duration.ofDays(1))
                 .sound("mySound.wav")
+                .subtitle("This is an iOS subtitle")
                 .build();
 
         String loadedJson = readFromFile("testMessage.json");
@@ -56,6 +57,7 @@ public class TestModels {
         assertEquals(message.getExpiration(), loadedMessage.getExpiration());
         assertEquals(message.getTtl(), loadedMessage.getTtl());
         assertEquals(message.getSound(), loadedMessage.getSound());
+        assertEquals(message.getSubtitle(), loadedMessage.getSubtitle());
 
 
     }

--- a/src/test/resources/com/kinoroy/expo/push/testMessage.json
+++ b/src/test/resources/com/kinoroy/expo/push/testMessage.json
@@ -20,5 +20,7 @@
 
   "badge": 11,
 
-  "channelId": "abc"
+  "channelId": "abc",
+
+  "subtitle": "This is an iOS subtitle"
 }


### PR DESCRIPTION
Adds the subtitle field (iOS only) as specified in https://docs.expo.io/guides/push-notifications/. Closes #3.