### PR TITLE
Extract invalid (DeviceNotRegistered) tokens from tickets

### DIFF
--- a/src/main/java/com/kinoroy/expo/push/Util.java
+++ b/src/main/java/com/kinoroy/expo/push/Util.java
@@ -1,0 +1,46 @@
+package com.kinoroy.expo.push;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Helpful utility methods
+ */
+public class Util {
+
+    /**
+     * @param pushTicketResponse The response to extract the tokens from
+     * @return A list of push tokens for messages that could not be delivered due to the token not being registered
+     * (DeviceNotRegistered).
+     */
+    public static List<String> extractNotRegisteredTokens(PushTicketResponse pushTicketResponse) {
+        if (pushTicketResponse.getTickets() == null) {
+            return Collections.emptyList();
+        }
+        return pushTicketResponse.getTickets().stream()
+                .map(Util::extractNotRegisteredToken)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @param pushTicket The ticket to extract the token from
+     * @return An optional invalid (DeviceNotRegistered) push token
+     */
+    public static Optional<String> extractNotRegisteredToken(PushTicket pushTicket) {
+        String startStr = "ExponentPushToken";
+        String endStr = "]";
+
+        if (pushTicket.getDetails() != null && PushError.DEVICE_NOT_REGISTERED.equals(pushTicket.getDetails().getError())
+                && pushTicket.getMessage() != null && pushTicket.getMessage().contains(startStr)) {
+            return Optional.of(
+                    pushTicket.getMessage().substring(pushTicket.getMessage().indexOf(startStr), pushTicket.getMessage().indexOf(endStr) + 1)
+            );
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/com/kinoroy/expo/push/TestExpoPushService.java
+++ b/src/test/java/com/kinoroy/expo/push/TestExpoPushService.java
@@ -3,22 +3,16 @@ package com.kinoroy.expo.push;
 import com.google.gson.GsonBuilder;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.jupiter.api.Assertions.*;
-import retrofit2.Response;
+
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.net.URL;
-import java.sql.Date;
-import java.time.Duration;
+
 import java.util.ArrayList;
-import java.util.HashMap;
-import static com.kinoroy.expo.push.Util.*;
+
+import static com.kinoroy.expo.push.TestUtil.*;
 
 public class TestExpoPushService {
 
@@ -87,6 +81,9 @@ public class TestExpoPushService {
         assertNull(t2.getDetails());
         assertEquals(t2.getId(), "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
 
+        assertEquals(1, Util.extractNotRegisteredTokens(res).size());
+        assertEquals("ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]", Util.extractNotRegisteredTokens(res).get(0));
+
     }
 
     @Test
@@ -135,7 +132,6 @@ public class TestExpoPushService {
         assertNull(r2.getDetails());
 
     }
-
 
     public void tearDown() throws Exception {
         mockServer.shutdown();

--- a/src/test/java/com/kinoroy/expo/push/TestModels.java
+++ b/src/test/java/com/kinoroy/expo/push/TestModels.java
@@ -4,16 +4,11 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 import java.util.HashMap;
 
-import static com.kinoroy.expo.push.Util.*;
+import static com.kinoroy.expo.push.TestUtil.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/kinoroy/expo/push/TestUtil.java
+++ b/src/test/java/com/kinoroy/expo/push/TestUtil.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 
-public class Util {
+public class TestUtil {
 
     public static String readFromFile(String fileName) throws Exception {
 


### PR DESCRIPTION
Closes #4. Extract all invalid (DeviceNotRegistered) tokens from a PushTicketResponse or the token from a single ticket.